### PR TITLE
Added IdaVSHelp

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ many other things like known strings and anti-debugging code which can be also m
   * Something that's also of considerable importance is that the IDA Toolbag lets you collaborate with other IDA users: one can publish his 'History', or import another user's history & even merge them!
   * See the official documentation for an extensive feature list.
 
+* [IdaVSHelp](https://github.com/andreafioraldi/IdaVSHelp): IDAPython plugin to integrate Visual Studio Help Viewer in IDA Pro >= 6.8
+
 * [IDAtropy](https://github.com/danigargu/IDAtropy): IDAtropy is a plugin for Hex-Ray's IDA Pro designed to generate charts of entropy and histograms using the power of idapython and matplotlib.
 
 * [IDA Xtensa](https://github.com/themadinventor/ida-xtensa): This is a processor plugin for IDA, to support the Xtensa core found in Espressif ESP8266. It does not support other configurations of the Xtensa architecture, but that is probably (hopefully) easy to implement.


### PR DESCRIPTION
Hi,
I developed a small plugin to integrate the Help Viewer of Visual Studio in IDA and I would be happy if you put it in this list.
IdaVSHelp: https://github.com/andreafioraldi/IdaVSHelp

To try the plugin you have to follow the instructions in the README.md file in the repo.
In short you must highligh a word in IDA and press Alt-H, the plugin will look for it in the offline Windows documentation.

Thanks and sorry for my awful english :)